### PR TITLE
Disable contrast check for non rgb colors

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -132,6 +132,10 @@ function contrast(rgb1, rgb2) {
 }
 
 function contrastMessage(color1, color2, size) {
+  if (!isRGB(color1) || !isRGB(color2)) {
+    return ' –';
+  }
+
   const ratio = contrast(RGBParts(color1), RGBParts(color2));
   const WCAGResult = meetWCAG(ratio, size);
   let message = round(ratio, 2);

--- a/src/client.js
+++ b/src/client.js
@@ -13,8 +13,7 @@ function getBgColor(el) {
     }
   }
 
-  // return defaultBg;
-  return 'rgb(255, 255, 255)'; // todo: handle rgba
+  return defaultBg;
 }
 
 function onMouseMove(e) {


### PR DESCRIPTION
Disable contrast check altogether if any of foreground or background is defined in anything other than rgb.

Note that the contrast checker is far from perfect. It doesn't take background images, opacity, being positioned about another element etc into account.

Fixes https://github.com/frederfred/fontanello/issues/14